### PR TITLE
ci(release): fix dry-run permissions; adhere to repo PR rules

### DIFF
--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -12,7 +12,7 @@ jobs:
     name: semantic-release dry-run
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       issues: read
       pull-requests: read
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,10 @@
 
 # 1.0.0 (2025-08-14)
 
-
 ### Features
 
-* **icon:** add Dark Auggie SVG icon and wire into node ([abf8629](https://github.com/rishitank/dark-auggie/commit/abf8629a64d0cd92d56e3fd33bfc13ae83886a70))
-* **node:** extend Dark Auggie with stdin, MCP flags, env injection, session controls; scaffold repo ([e739f8b](https://github.com/rishitank/dark-auggie/commit/e739f8b495b8a4143715f89bbdc4193c6ef65729))
+- **icon:** add Dark Auggie SVG icon and wire into node ([abf8629](https://github.com/rishitank/dark-auggie/commit/abf8629a64d0cd92d56e3fd33bfc13ae83886a70))
+- **node:** extend Dark Auggie with stdin, MCP flags, env injection, session controls; scaffold repo ([e739f8b](https://github.com/rishitank/dark-auggie/commit/e739f8b495b8a4143715f89bbdc4193c6ef65729))
 
 All notable changes to this project will be documented in this file by semantic-release.
 


### PR DESCRIPTION
This PR adjusts the dry-run release workflow to allow semantic-release to exercise push/tag operations during dry-run, and aligns with repository rules requiring changes via PR.

Changes
- release-dry-run.yml: set permissions.contents: write (was read)

Why
- Dry-run currently fails with EGITNOPERMISSION: Cannot push to the Git repository (semantic-release attempts a `git push --dry-run` to verify perms). The repo enforces PR-only changes and likely limited default permissions on PR events.
- Granting `contents: write` on the dry-run job enables semantic-release to simulate push/tag without actually modifying refs, unblocking dry-run checks.

Notes
- The actual Release workflow already has contents: write and uses push/master|main triggers.
- No functional code changes.

After merge
- Re-run Release (dry-run) via workflow_dispatch to confirm success.
- Optionally run Release workflow if desired.